### PR TITLE
feat: added retries & model parse fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1966,7 +1966,7 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dria-oracle"
-version = "0.2.36"
+version = "0.2.37"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -1993,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "dria-oracle-contracts"
-version = "0.2.36"
+version = "0.2.37"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2002,7 +2002,7 @@ dependencies = [
 
 [[package]]
 name = "dria-oracle-storage"
-version = "0.2.36"
+version = "0.2.37"
 dependencies = [
  "alloy",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["core"]
 
 [workspace.package]
 edition = "2021"
-version = "0.2.36"
+version = "0.2.37"
 license = "Apache-2.0"
 readme = "README.md"
 authors = ["erhant"]

--- a/core/src/cli/commands/mod.rs
+++ b/core/src/cli/commands/mod.rs
@@ -56,7 +56,7 @@ pub enum Commands {
         )]
         task_id: Option<U256>,
     },
-    /// View tasks. fsdkhfk fsdkjfdks
+    /// View tasks.
     View {
         #[arg(long, help = "Starting block number, defaults to 'earliest'.", value_parser = parse_block_number_or_tag)]
         from: Option<BlockNumberOrTag>,

--- a/core/src/compute/execute.rs
+++ b/core/src/compute/execute.rs
@@ -1,0 +1,43 @@
+use core::time::Duration;
+use dkn_workflows::{Executor, Model, ProgramMemory, Workflow};
+use eyre::Context;
+
+/// A wrapper for executing a workflow with retries.
+///
+/// - Creates an `Executor` with the given model.
+/// - Executes the given workflow with the executor over an empty memory.
+/// - If the execution fails due to timeout, retries up to 3 times with slightly increasing timeout durations.
+pub async fn execute_workflow_with_timedout_retries(
+    workflow: &Workflow,
+    model: Model,
+    duration: Duration,
+) -> eyre::Result<String> {
+    const NUM_RETRIES: usize = 3;
+
+    let mut retries = 0;
+    let executor = Executor::new(model);
+    while retries < NUM_RETRIES {
+        let mut memory = ProgramMemory::new();
+        tokio::select! {
+            result = executor.execute(None, &workflow, &mut memory) => {
+              return result.wrap_err("could not execute worfklow");
+            },
+            // normally the workflow has a timeout logic as well, but it doesnt work that well, and may get stuck
+            _ = tokio::time::sleep(duration) => {
+                // if we have retries left, log a warning and continue
+                // note that other errors will be returned as is
+                if retries < NUM_RETRIES {
+                  retries += 1;
+                  log::warn!("Execution timed out, retrying {}/{}", retries + 1, NUM_RETRIES);
+                  continue;
+                }
+            }
+        };
+    }
+
+    // all retries failed
+    return Err(eyre::eyre!(
+        "Execution timed out after {} retries",
+        NUM_RETRIES
+    ));
+}

--- a/core/src/compute/mod.rs
+++ b/core/src/compute/mod.rs
@@ -12,3 +12,6 @@ pub use validation::handle_validation;
 
 mod utils;
 use utils::parse_downloadable;
+
+mod execute;
+use execute::execute_workflow_with_timedout_retries;

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -28,8 +28,8 @@ async fn main() -> eyre::Result<()> {
 
     // log about env usage after env logger init is executed
     match dotenv_result {
-        Ok(_) => log::info!("Loaded .env file at: {}", cli.env.display()),
-        Err(e) => log::warn!("Could not load .env file: {}", e),
+        Ok(_) => eprintln!("Loaded .env file at: {}", cli.env.display()),
+        Err(e) => eprintln!("Could not load .env file: {}", e),
     }
 
     // read required env variables


### PR DESCRIPTION
- Fixed a wrong help message on `View` command
- Added fallback to model choice, e.g. if the user gives an unknown model `hfkdjhkjsdh` to the contract, nodes will respond with any of the nodes that they are running at the time; this helps with a type of oracle attack where the model is specifically given by the user to be unparsable so that their own oracle can respond to it
- Added retry-mechanism to all workflows in case they time out, resolves #43 
- Fixed duration check on `Generation::Workflow` by using tokio instead